### PR TITLE
Responsive

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -29,22 +29,29 @@ $o-grid-is-silent: false;
 	}
 }
 
-$body-max-height: 330px;
-$body-stretch-height: 75vw;
-$body-affine-height: 40px;
+$form-stretch-height: 75vw;
+$form-affine-height: 40px;
 
-body {
-	margin: 0;
-	height: $body-max-height;
+html, body {
+	height: 100%;
+}
+
+%vertical-center {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-around;
+}
+
+body {
+	@extend %vertical-center;
+	margin: 0;
 	padding: 15px 0;
 	box-sizing: border-box;
 }
 
 .distro-light-signup--body-wrapper {
-	height: calc(#{$body-affine-height} + #{$body-stretch-height});
+	@extend %vertical-center;
+	height: calc(#{$form-affine-height} + #{$form-stretch-height});
 }
 
 .distro-light-signup--flex-wrapper {
@@ -61,9 +68,7 @@ body {
 }
 
 .o-email-only-signup {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-around;
+	@extend %vertical-center;
 }
 
 .o-email-only-signup.o-email-only-signup {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -9,13 +9,42 @@ $o-grid-is-silent: false;
 @include oFontsInclude(MetricWeb, light);
 @include oFontsInclude(MetricWeb, bold);
 
+@function pxAndVwToViewport($vw, $px) {
+	@return $px * 100vw / $vw;
+}
+
+@mixin responsive($size, $min: 0, $max: 0, $prop: 'font-size') {
+	#{$prop}: $size;
+
+	@if $min != 0 {
+		@media (max-width: pxAndVwToViewport($size, $min)) {
+			#{$prop}: $min;
+		}
+	}
+
+	@if $max != 0 {
+		@media (min-width: pxAndVwToViewport($size, $max)) {
+			#{$prop}: $max;
+		}
+	}
+}
+
+$body-max-height: 330px;
+$body-stretch-height: 75vw;
+$body-affine-height: 40px;
+
 body {
 	margin: 0;
-
-	// Ensure the .o-email-only-signup div is allowed to expand to full height
-	position: absolute;
-	min-height: 100%;
+	height: $body-max-height;
 	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+	padding: 15px 0;
+	box-sizing: border-box;
+}
+
+.distro-light-signup--body-wrapper {
+	height: calc(#{$body-affine-height} + #{$body-stretch-height});
 }
 
 .distro-light-signup--flex-wrapper {
@@ -31,8 +60,44 @@ body {
   line-height: 26px;
 }
 
+.o-email-only-signup {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+}
+
 .o-email-only-signup.o-email-only-signup {
 	// o-email-only-signup assumes the parent component can set side padding, but in FIA
 	// we have no control. Override manually here instead
 	padding: 15px 15px 0;
+	margin: 0;
+}
+
+.o-email-only-signup__heading {
+	@include responsive(6vw, $min: 15px, $max: 24px);
+}
+
+.o-email-only-signup__email,
+.o-email-only-signup__submit,
+.o-email-only-signup__text {
+	@include responsive(4.5vw, $min: 13.5px, $max: 18px);
+}
+
+.o-email-only-signup__no-spam {
+	@include responsive(3.5vw, $min: 9px, $max: 14px);
+}
+
+.o-email-only-signup__text,
+.o-email-only-signup__no-spam {
+	line-height: 1.1;
+}
+
+.o-email-only-signup__heading,
+.o-email-only-signup__email,
+.o-email-only-signup__submit {
+	line-height: 1;
+}
+
+.o-email-only-signup__secondary {
+	@include responsive(4vw, $prop: 'margin-top', $min: 8px, $max: 16px);
 }

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -7,7 +7,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 </head>
 <body>
-	{{{body}}}
+	<div class="distro-light-signup--body-wrapper">
+		{{{body}}}
+	</div>
 
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch&amp;flags=gated&amp;unknown=polyfill"></script>
 {{#unless showFormHack}}


### PR DESCRIPTION
This feels really hacky but it more or less works.

- Vertically center everything in the body
- Size most things with viewport units with min and max sizes
- "Most things" includes the form itself so it keeps a more or less constant aspect ratio
- The aspect ratio will never go below 16:15 (i.e. 320×300), so we can size the iframe to that.
- It won't go much above 16:15 because viewport units. At iPhone 6 plus size it's about 5:4 (vs about 7:5 without this PR).
- Because everything is vertically centered any whitespace is spread around.

Screenshots forthcoming once there's a PR app deployed.